### PR TITLE
Added passthrough Quant class

### DIFF
--- a/src/qonnx/custom_op/general/__init__.py
+++ b/src/qonnx/custom_op/general/__init__.py
@@ -35,6 +35,7 @@ from qonnx.custom_op.general.intquant import IntQuant
 from qonnx.custom_op.general.maxpoolnhwc import MaxPoolNHWC
 from qonnx.custom_op.general.multithreshold import MultiThreshold
 from qonnx.custom_op.general.quantavgpool2d import QuantAvgPool2d
+from qonnx.custom_op.general.quant import Quant
 from qonnx.custom_op.general.trunc import Trunc
 from qonnx.custom_op.general.xnorpopcount import XnorPopcountMatMul
 

--- a/src/qonnx/custom_op/general/quant.py
+++ b/src/qonnx/custom_op/general/quant.py
@@ -26,11 +26,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from qonnx.custom_op.general.intquant import IntQuant as Quant
+from qonnx.custom_op.general.intquant import IntQuant
 from qonnx.custom_op.general.intquant import int_quant as quant
 from qonnx.custom_op.general.intquant import max_int, min_int, resolve_rounding_mode
+from qonnx.custom_op.registry import register_op
 
-Quant = Quant
+# Create alias and register it separately for "Quant" op_type
+@register_op(domain="qonnx.custom_op.general", op_type="Quant")
+class Quant(IntQuant):
+    """Alias for IntQuant to support legacy \"Quant\" op_type."""
+    pass
+
+# Re-export functions
 quant = quant
 max_int = max_int
 min_int = min_int


### PR DESCRIPTION
## Fix decorator registration for Quant custom op

### Problem
The decorator registration system introduced in dfc4bd8 broke when `Quant` was replaced with `IntQuant`/`FloatQuant`. Nodes with `op_type="Quant"` (created by transformations like `QCDQToQuant`) failed to resolve because no handler was registered for "Quant" in `CUSTOM_OP_REGISTRY`.

### Solution
- Created `Quant` class in `quant.py` that inherits from `IntQuant` 
- Added `@register_op(domain="qonnx.custom_op.general", op_type="Quant")` decorator
- Imported `Quant` in `__init__.py` to make it available

### Impact
- ✅ Restores compatibility for `op_type="Quant"` nodes
- ✅ Both "Quant" and "IntQuant" nodes work correctly
- ✅ No breaking changes - maintains full backward compatibility
- ✅ Fixes transformations that create Quant nodes (e.g., `QCDQToQuant`)

Tested with models using `QCDQToQuant` transformation - all Quant nodes now resolve and execute correctly.